### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/abubakar0320/Jamia-shere-rabbani/security/code-scanning/2](https://github.com/abubakar0320/Jamia-shere-rabbani/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block specifying the least privileges required to the workflow. In this case, since the workflow only checks out code and installs/builds dependencies (no artifact uploads, releases, or pull request modifications), the minimal necessary permission is `contents: read`. You can add the `permissions` block at the workflow root (top-level, just below the `name:`), or at each job (under `jobs` > `build`). Since there is only one job and no differing permission requirements, setting it at the workflow root is simplest and clearest.

This involves editing `.github/workflows/ci.yml` to add:
```yaml
permissions:
  contents: read
```
immediately after the `name: CI` line, before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
